### PR TITLE
feat(container): style the container class and its adaptive version

### DIFF
--- a/src/sass/base/_container.scss
+++ b/src/sass/base/_container.scss
@@ -1,0 +1,16 @@
+.container {
+  margin: 0 auto;
+  padding: 0 20px;
+  max-width: 100%;
+  @media screen and (min-width: 480px) {
+    max-width: 480px;
+  }
+  @media screen and (min-width: 768px) {
+    max-width: 768px;
+    padding: 0 34px;
+  }
+  @media screen and (min-width: 1280px) {
+    max-width: 1280px;
+    padding: 0 115px;
+  }
+}

--- a/src/sass/base/_container.scss
+++ b/src/sass/base/_container.scss
@@ -6,11 +6,9 @@
     max-width: 480px;
   }
   @media screen and (min-width: 768px) {
-    max-width: 768px;
-    padding: 0 34px;
+    max-width: 740px;
   }
   @media screen and (min-width: 1280px) {
-    max-width: 1280px;
-    padding: 0 115px;
+    max-width: 1090px;
   }
 }


### PR DESCRIPTION
Добавлены защитные `padding` в `20px`  до планшетной версии, где они после были изменены. При использовании свойства `box-sizing: border-box` все будет работать корректно.

Я использовала `padding` таким образом так как в декстопной версии на макете на самом деле контейнер размером в `1050px`, однако задана точка перелома в `1280px`. а так же в хэдере логотип выходит за пределы контенера - это можно было решить просто абсолютным позиционированием, однако такая же проблема наблюдается и в секции героя.

Хотя круги которые являются `::after` для цыфрового обозначения количества кафе и фуд-траков все таки будет выходить за пределы контейнера.